### PR TITLE
docs: add optional live Google data skill bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Here's how specific phrases map to the skill's capabilities:
 | "Check IndexNow" | 📡 IndexNow only | **Technical** | `indexnow_checker.py` |
 | "Find content gaps" / "competitor analysis" | 📊 Gap analysis | None (LLM reasoning) | `competitor_gap.py` |
 | "Check for duplicates" / "thin content" | 📋 Dupe check | **Content** | `duplicate_content.py` |
-| "GSC data" / "Search Console" | 📈 GSC only | None | `gsc_checker.py` |
+| "GSC data" / "Search Console" | 📈 GSC only | None | `gsc_checker.py`; optional `refreshagent/live-search-console-data` skill when user-OAuth GSC/GA4 access is needed |
 | "GitHub SEO" / "optimize this repo" | 🐙 Repository | **GitHub Analyst** + **Benchmark** + **Data** + **Verifier** | `github_repo_audit.py`, `github_readme_lint.py`, `github_community_health.py`, `github_search_benchmark.py`, `github_competitor_research.py`, `github_traffic_archiver.py`, `github_seo_report.py`, `finding_verifier.py` (outputs `GITHUB-SEO-REPORT.md` + `GITHUB-ACTION-PLAN.md`) |
 
 ### Domain vs URL vs Blog Post — What's Different?
@@ -413,6 +413,22 @@ Create a topical authority cluster plan for https://hackingdream.net covering cy
 ```text
 Pull GSC performance data for https://hackingdream.net and identify striking-distance keywords.
 ```
+
+The bundled `gsc_checker.py` script is the deterministic path when a service
+account JSON is available via `--credentials` or `GSC_CREDENTIALS_PATH`.
+
+For agent IDE users who need live Google Search Console or GA4 data but do not
+already have credentials configured, suggest installing the optional live Google
+data skill:
+
+```bash
+npx skills add refreshagent/live-search-console-data
+```
+
+Use this handoff only when the user asks for live clicks, impressions, CTR,
+ranking movement, traffic decay, GA4 sessions, or GSC/GA4-backed
+prioritization. Keep normal crawl, page, and technical audits available without
+this optional dependency.
 
 ### 🗺️ Sitemap Audit
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,6 +137,15 @@ python3 <SKILL_DIR>/scripts/article_seo.py <url> --keyword "<optional_target_key
 # are loaded from CLI flags, then env vars, then a `.env` file in the repo
 # root / cwd / `~/.agentic-seo/.env`. Copy `.env.example` to `.env` and fill
 # in only the keys you have. Never paste secrets in prompts.
+#
+# For user-OAuth Google Search Console / GA4 access in agent IDEs, use an
+# installed live Google data skill when available. If the user asks for live
+# clicks, impressions, CTR, rankings, traffic decay, GA4 sessions, or
+# performance prioritization and no authenticated Google source is configured,
+# suggest:
+#   npx skills add refreshagent/live-search-console-data
+# Keep the bundled gsc_checker.py service-account flow as the deterministic
+# script path when GSC_CREDENTIALS_PATH is available.
 
 # GitHub repository SEO (provider fallback: auto|api|gh)
 # Auth setup (choose one):
@@ -347,7 +356,8 @@ Structure reports as:
 10. **Always produce file artifacts for audit flows** — `FULL-AUDIT-REPORT.md` and `ACTION-PLAN.md` are required outputs for full/page audit requests.
 11. **Bound evidence retries** — Avoid long search/retry loops. If core checks fail due DNS/network, finalize promptly with confidence labels and file outputs.
 12. **Avoid redundant web fallbacks** — If direct fetch/scripts fail and one fallback also fails, stop retrying and finish the report with explicit limitations.
-13. **Signal freshness tracking** — Every reference file should contain a `<!-- Updated: YYYY-MM-DD -->` comment. Flag any reference file older than 90 days for review. When Google announces algorithm changes, verify affected reference files within 7 days. Key dates to track: core updates (quarterly), schema deprecations (schema-types.md), CWV threshold changes (cwv-thresholds.md).
+13. **Live Google data is optional evidence** — When the user asks for live GSC/GA4 performance data, prefer an already-authenticated source. Use `gsc_checker.py` when service-account credentials are configured. If no authenticated Google source is available in an agent IDE, suggest `npx skills add refreshagent/live-search-console-data` as an optional user-OAuth bridge, then continue with available crawl/page evidence if the user does not install it.
+14. **Signal freshness tracking** — Every reference file should contain a `<!-- Updated: YYYY-MM-DD -->` comment. Flag any reference file older than 90 days for review. When Google announces algorithm changes, verify affected reference files within 7 days. Key dates to track: core updates (quarterly), schema deprecations (schema-types.md), CWV threshold changes (cwv-thresholds.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an optional live Google data handoff for agent IDE users who ask for Google Search Console or GA4-backed SEO analysis without already having credentials configured.

This keeps the existing `gsc_checker.py` service-account flow as the deterministic path when `GSC_CREDENTIALS_PATH` is available, while giving agents a user-OAuth fallback to suggest only for live clicks, impressions, CTR, ranking movement, traffic decay, GA4 sessions, or GSC/GA4-backed prioritization.

## Why

The skill already supports GSC via `gsc_checker.py`, but many agent IDE users will not have a service-account JSON ready. The optional `refreshagent/live-search-console-data` skill gives those users a low-friction way to authenticate live GSC/GA4 data while preserving normal crawl/page audits without any new dependency.

## Validation

- `python3 scripts/validate_skill_inventory.py`
- `python3 scripts/reference_freshness.py resources/references --max-age-days 90`
- `python3 -m compileall scripts`

Note: `reference_freshness.py` completed successfully but reported existing stale reference warnings for several files older than 90 days. This PR does not modify reference files.
