### PR TITLE
Fix author and publish-date detection in article_seo

### DIFF
--- a/scripts/article_seo.py
+++ b/scripts/article_seo.py
@@ -151,19 +151,33 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
         result["og_description"] = og_desc.get("content", "")
 
     # ── Author ─────────────────────────────────────────────────────────────
-    author_tag = (
-        soup.find(attrs={"class": re.compile(r"author|byline", re.I)})
-        or soup.find("span", itemprop="author")
-        or soup.find("a", rel="author")
+    # Meta tags first: they are unambiguous, whereas a class~=author match can hit a
+    # sidebar widget. JSON-LD last, because it needs parsing.
+    author_meta = (
+        soup.find("meta", attrs={"name": "author"})
+        or soup.find("meta", attrs={"property": "article:author"})
     )
-    if author_tag:
-        result["author"] = author_tag.get_text(strip=True)[:100]
+    if author_meta and author_meta.get("content"):
+        result["author"] = author_meta["content"].strip()[:100]
+    else:
+        author_tag = (
+            soup.find(attrs={"class": re.compile(r"author|byline", re.I)})
+            or soup.find("span", itemprop="author")
+            or soup.find("a", rel="author")
+        )
+        if author_tag:
+            result["author"] = author_tag.get_text(strip=True)[:100]
+        else:
+            result["author"] = _author_from_jsonld(soup)
 
     # ── Publish date ───────────────────────────────────────────────────────
     for sel in [
         {"itemprop": "datePublished"},
-        {"class": re.compile(r"published|post-date|entry-date", re.I)},
+        # OpenGraph emits `property=`, not `name=`, so the name-based selector below
+        # can never match on a standards-compliant page.
+        {"property": "article:published_time"},
         {"name": "article:published_time"},
+        {"class": re.compile(r"published|post-date|entry-date", re.I)},
     ]:
         date_tag = soup.find(attrs=sel) if isinstance(sel, dict) else None
         if date_tag:
@@ -171,6 +185,12 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
                 date_tag.get("content") or date_tag.get("datetime") or date_tag.get_text(strip=True)
             )[:50]
             break
+    if not result["publish_date"]:
+        time_tag = soup.find("time", attrs={"datetime": True})
+        if time_tag:
+            result["publish_date"] = time_tag["datetime"][:50]
+    if not result["publish_date"]:
+        result["publish_date"] = _jsonld_field(soup, "datePublished")[:50]
 
     # ── CMS-specific body container ────────────────────────────────────────
     body_container = None
@@ -250,6 +270,48 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
 # ---------------------------------------------------------------------------
 # JSON-LD structured data extraction
 # ---------------------------------------------------------------------------
+
+def _iter_jsonld(soup: BeautifulSoup):
+    """Yield every JSON-LD object on the page, flattening @graph and top-level lists."""
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads((script.string or "").strip())
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        stack = data if isinstance(data, list) else [data]
+        while stack:
+            node = stack.pop()
+            if not isinstance(node, dict):
+                continue
+            graph = node.get("@graph")
+            if isinstance(graph, list):
+                stack.extend(graph)
+            yield node
+
+
+def _jsonld_field(soup: BeautifulSoup, field: str) -> str:
+    """First non-empty string value of `field` across all JSON-LD nodes."""
+    for node in _iter_jsonld(soup):
+        value = node.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _author_from_jsonld(soup: BeautifulSoup) -> str:
+    """Author name from JSON-LD, whether it is a string, an object, or a list of either."""
+    for node in _iter_jsonld(soup):
+        author = node.get("author")
+        if isinstance(author, list):
+            author = author[0] if author else None
+        if isinstance(author, dict):
+            name = author.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()[:100]
+        elif isinstance(author, str) and author.strip():
+            return author.strip()[:100]
+    return ""
+
 
 def extract_structured_data(soup: BeautifulSoup) -> list:
     """

--- a/tests/test_article_seo_extraction.py
+++ b/tests/test_article_seo_extraction.py
@@ -1,0 +1,87 @@
+import importlib.util
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+spec = importlib.util.spec_from_file_location("article_seo", SCRIPTS / "article_seo.py")
+article_seo = importlib.util.module_from_spec(spec)
+sys.modules["article_seo"] = article_seo
+spec.loader.exec_module(article_seo)
+
+from bs4 import BeautifulSoup  # noqa: E402
+
+
+# No class~=author, no span[itemprop=author], no a[rel=author]. Author and date are
+# carried only by meta tags, <time> and JSON-LD — the shape a Next.js/Astro site emits.
+META_ONLY = """<!doctype html>
+<html lang="en">
+<head>
+  <title>Procedural puzzle generation</title>
+  <meta name="author" content="Ada Analyst">
+  <meta property="article:published_time" content="2026-08-10T00:00:00.000Z">
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"BlogPosting",
+   "author":{"@type":"Person","name":"Ada Analyst"},
+   "datePublished":"2026-08-10T00:00:00.000Z"}
+  </script>
+</head>
+<body><main><h1>Procedural puzzle generation</h1><p>Body copy.</p></main></body>
+</html>"""
+
+# Author and date reachable only through JSON-LD, and nested under @graph.
+JSONLD_GRAPH_ONLY = """<!doctype html>
+<html lang="en">
+<head>
+  <title>Graph only</title>
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@graph":[
+    {"@type":"WebSite","name":"Example"},
+    {"@type":"BlogPosting","author":{"@type":"Person","name":"Grace Graph"},
+     "datePublished":"2026-07-01"}
+  ]}
+  </script>
+</head>
+<body><main><h1>Graph only</h1><p>Body copy.</p></main></body>
+</html>"""
+
+TIME_ELEMENT_ONLY = """<!doctype html>
+<html lang="en">
+<head><title>Time only</title></head>
+<body><main><h1>Time only</h1><time datetime="2026-06-15">15 June 2026</time></main></body>
+</html>"""
+
+
+def _extract(html):
+    soup = BeautifulSoup(html, "html.parser")
+    return article_seo.extract_content(soup, article_seo.detect_cms(soup, ""))
+
+
+def test_author_from_meta_tag():
+    assert _extract(META_ONLY)["author"] == "Ada Analyst"
+
+
+def test_publish_date_from_opengraph_property_attribute():
+    # Regression: the selector used {"name": "article:published_time"}, but OpenGraph
+    # emits property=, so this returned "" on every standards-compliant page.
+    assert _extract(META_ONLY)["publish_date"].startswith("2026-08-10")
+
+
+def test_author_and_date_from_jsonld_graph():
+    result = _extract(JSONLD_GRAPH_ONLY)
+    assert result["author"] == "Grace Graph"
+    assert result["publish_date"].startswith("2026-07-01")
+
+
+def test_publish_date_from_time_element():
+    assert _extract(TIME_ELEMENT_ONLY)["publish_date"].startswith("2026-06-15")
+
+
+def test_visible_byline_still_wins_over_jsonld_absence():
+    html = """<html><head><title>T</title></head><body><main>
+    <p class="byline">By Classic Byline</p><h1>T</h1></main></body></html>"""
+    assert _extract(html)["author"] == "By Classic Byline"


### PR DESCRIPTION
## What this fixes

Two extractors in `article_seo.py` miss the markup that modern static-site generators emit, so a fully-marked-up article reports:

```
Author            : ⚠️ Not detected
Publish Date      : Not detected
```

...and then raises `[E-E-A-T] No author attribution detected` and `[Freshness] No publish date detected in markup` as findings. Both are false on such a page.

### Author

Only `class~=author|byline`, `span[itemprop=author]` and `a[rel=author]` were checked. Not consulted:

- `<meta name="author">`
- `<meta property="article:author">`
- JSON-LD `author`

### Publish date

The selector list contained `{"name": "article:published_time"}` — but OpenGraph emits `property=`, not `name=`, so **that entry can never match on a standards-compliant page**. `<time datetime>` and JSON-LD `datePublished` were also not consulted.

## Approach

Adds `_iter_jsonld` / `_jsonld_field` / `_author_from_jsonld`, which flatten `@graph` and top-level arrays, then wires them in as a last-resort fallback.

Lookup order is deliberate: unambiguous meta tags first (a `class~=author` match can hit a sidebar widget), the existing DOM heuristics second, JSON-LD last because it needs parsing. **Existing behaviour is unchanged when a visible byline is present** — there is a test for that.

## Validation

```
python3 -m pytest tests/ -q                    # 39 passed
python3 scripts/validate_skill_inventory.py    # OK: documented inventory matches files on disk
python3 -m compileall scripts                  # OK
```

New `tests/test_article_seo_extraction.py` covers meta-only, `@graph`-only and `<time>`-only pages. **Four of its five tests fail against the current extractor** and pass after this change; the fifth guards the existing byline path against regression.

## Not included

The keyword extractor returns `one` as the target keyword on long articles (then suggests *oneplus*, *onedrive*) because `STOP_WORDS` lacks common filler. That felt like a separate, more subjective change — happy to send it as its own PR if useful.