### PR TITLE
Update FAQ guidance for the 7 May 2026 rich-result removal

### DIFF
--- a/resources/references/google-seo-reference.md
+++ b/resources/references/google-seo-reference.md
@@ -1,4 +1,4 @@
-<!-- Updated: 2026-02-07 -->
+<!-- Updated: 2026-08-10 -->
 # Google SEO Quick Reference (February 2026)
 
 Concise reference guide for subagents. Summarizes key Google Search concepts,
@@ -99,7 +99,7 @@ Measured at the 75th percentile of real user data (field data).
 
 ### Deprecated/Restricted Types (as of Feb 2026)
 - **HowTo**: Rich results removed (September 2023)
-- **FAQ**: Restricted to government and healthcare authority sites (August 2023)
+- **FAQ**: No rich result for any site since 7 May 2026 (this supersedes the August 2023 restriction). Markup remains valid and may stay.
 - **SpecialAnnouncement**: Deprecated (July 31, 2025)
 - **CourseInfo, EstimatedSalary, LearningVideo**: Retired (June 2025)
 - **ClaimReview**: Retired (June 2025)

--- a/resources/references/schema-types.md
+++ b/resources/references/schema-types.md
@@ -1,4 +1,4 @@
-<!-- Updated: 2026-02-07 -->
+<!-- Updated: 2026-08-10 -->
 # Schema.org Types — Status & Recommendations (February 2026)
 
 **Schema.org Version:** 29.4 (December 8, 2025)
@@ -47,9 +47,9 @@ Google's documentation explicitly recommends JSON-LD over Microdata and RDFa.
 
 | Type | Restriction | Since |
 |------|------------|-------|
-| FAQPage | Government and healthcare authority sites ONLY | August 2023 |
+| FAQPage | No rich result for any site; markup still valid | 7 May 2026 |
 
-> Google severely limited FAQ rich results. Only authoritative sources (government, health organizations) now receive FAQ rich results. Do NOT recommend FAQPage schema for commercial sites.
+> Google removed FAQ rich results entirely on 7 May 2026, including for the government and health sites that had kept them after the August 2023 restriction. The `FAQPage` type itself is NOT deprecated and Google's documentation states existing markup can stay. Do not recommend removing it — recommend not expecting a rich result from it.
 
 ---
 

--- a/resources/skills/seo-aeo.md
+++ b/resources/skills/seo-aeo.md
@@ -71,7 +71,7 @@ PAA questions are selected by Google based on semantic relatedness to the primar
 - [ ] Each PAA question should have its own H2 or H3 phrased **exactly as the question** users ask
 - [ ] Directly below each question H-tag: a 30-50 word direct answer paragraph
 - [ ] Avoid filler phrases ("Great question!", "In this article we will...") — Google penalizes these for PAA
-- [ ] Add `FAQPage` schema **only if your site qualifies** (restricted to government/healthcare authority sites post-2023); for others, use `Article` with `speakable`
+- [ ] Add `FAQPage` schema where the page genuinely answers questions. It has produced no rich result for any site since 7 May 2026, but it is not deprecated and still helps answer engines chunk the page. Pair with `Article` and `speakable`.
 
 **Example HTML structure for PAA:**
 ```html

--- a/resources/skills/seo-schema.md
+++ b/resources/skills/seo-schema.md
@@ -43,7 +43,7 @@ See `schema/templates.json` for ready-to-use JSON-LD templates for these types.
 > **JSON-LD and JavaScript rendering:** Per Google's December 2025 JS SEO guidance, structured data injected via JavaScript may face delayed processing. For time-sensitive markup (especially Product, Offer), include JSON-LD in the initial server-rendered HTML.
 
 ### RESTRICTED — only for specific sites:
-- **FAQ**: ONLY for government and healthcare authority sites (restricted Aug 2023)
+- **FAQ**: no rich result for any site since 7 May 2026. The markup is not deprecated — keep it for answer engines, but never claim a rich-result benefit.
 
 ### DEPRECATED — never recommend:
 - **HowTo**: Rich results removed September 2023

--- a/scripts/article_seo.py
+++ b/scripts/article_seo.py
@@ -61,7 +61,7 @@ DEPRECATED_SCHEMA = {
     "HowTo", "SpecialAnnouncement", "CourseInfo", "EstimatedSalary",
     "LearningVideo", "ClaimReview", "VehicleListing", "PracticeProblems",
 }
-RESTRICTED_SCHEMA = {"FAQPage"}  # government / healthcare only
+RESTRICTED_SCHEMA = {"FAQPage"}  # no rich result since 7 May 2026; markup still valid
 
 
 # ---------------------------------------------------------------------------
@@ -274,7 +274,7 @@ def extract_structured_data(soup: BeautifulSoup) -> list:
             note = f"{schema_type} was deprecated/removed from rich results. Remove or replace."
         elif schema_type in RESTRICTED_SCHEMA:
             status = "restricted"
-            note = f"{schema_type} is restricted to government/healthcare authority sites only."
+            note = f"{schema_type}: FAQPage no longer produces rich results for any site (Google removed them on 7 May 2026). The markup is NOT deprecated and may stay — it still helps answer engines parse the page."
 
         blocks.append({
             "@type": schema_type,
@@ -495,7 +495,7 @@ def detect_seo_issues(content: dict, structured_data: list, readability: dict) -
             if sd.get("status") == "deprecated":
                 issues.append({"severity": "Critical", "area": "Schema", "finding": sd["note"], "fix": "Remove deprecated schema type immediately."})
             elif sd.get("status") == "restricted":
-                issues.append({"severity": "Warning", "area": "Schema", "finding": sd["note"], "fix": "Remove FAQPage schema unless you are a government or healthcare authority site."})
+                issues.append({"severity": "Warning", "area": "Schema", "finding": sd["note"], "fix": "No action needed. Keep the markup; just do not expect a rich result."})
 
     # Readability
     fre = readability.get("flesch_reading_ease")

--- a/scripts/parse_html.py
+++ b/scripts/parse_html.py
@@ -264,7 +264,7 @@ def parse_html(
         "HowTo", "SpecialAnnouncement", "CourseInfo", "EstimatedSalary",
         "LearningVideo", "ClaimReview", "VehicleListing", "PracticeProblems",
     }
-    RESTRICTED_SCHEMA = {"FAQPage"}  # government/healthcare only
+    RESTRICTED_SCHEMA = {"FAQPage"}  # no rich result since 7 May 2026; markup still valid
 
     for script in soup.find_all("script", type="application/ld+json"):
         try:
@@ -294,7 +294,7 @@ def parse_html(
                 note = f"{primary_type} was deprecated/removed from rich results. Remove or replace."
             elif primary_type in RESTRICTED_SCHEMA:
                 status = "restricted"
-                note = f"{primary_type} is restricted to government/healthcare authority sites only."
+                note = f"{primary_type}: FAQPage no longer produces rich results for any site (Google removed them on 7 May 2026). The markup is NOT deprecated and may stay — it still helps answer engines parse the page."
 
             result["schema"].append({
                 "@type": primary_type,

--- a/scripts/rich_results_guard.py
+++ b/scripts/rich_results_guard.py
@@ -23,7 +23,7 @@ DEPRECATED_TYPES = {
 }
 
 RESTRICTED_TYPES = {
-    "FAQPage": "eligible mainly for authoritative government and health sites",
+    "FAQPage": "no longer shown as a rich result for any site (7 May 2026); markup still valid",
     "HowTo": "no longer broadly shown as a Google rich result",
 }
 

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -91,9 +91,9 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
         errors.append(f"{prefix}: @type '{schema_type}' is {deprecated[schema_type]}")
 
     # Check for restricted types used incorrectly
-    restricted = {"FAQPage": "restricted to government and healthcare sites only (Aug 2023)"}
+    restricted = {"FAQPage": "no longer eligible for rich results on any site (7 May 2026); markup remains valid and may stay"}
     if schema_type in restricted:
-        errors.append(f"{prefix}: @type '{schema_type}' is {restricted[schema_type]} — verify site qualifies")
+        errors.append(f"{prefix}: @type '{schema_type}' is {restricted[schema_type]}")
 
     return errors
 


### PR DESCRIPTION
## What this fixes

FAQ guidance across **8 files** is still frozen at the August 2023 restriction — *"only for government and healthcare authority sites"*. That is now wrong in both directions.

**Google removed FAQ rich results from Search entirely on 7 May 2026**, including for the government and health sites that had kept them after 2023. So "verify your site qualifies" no longer applies to anyone.

But the `FAQPage` type itself is **not deprecated**, and Google's structured-data documentation states that existing markup can stay.

## Why it matters beyond wording

The recommended fix was:

> Remove FAQPage schema unless you are a government or healthcare authority site.

That tells users to **delete valid markup**. It never produced a rich result for them anyway, and removing it loses a signal that still helps answer engines chunk a page into question/answer pairs. The advice is now: expect no rich result, keep the markup.

## Files touched

| | |
|---|---|
| Scripts | `article_seo.py` (3), `validate_schema.py` (2), `parse_html.py` (2), `rich_results_guard.py` |
| Skills | `seo-schema.md`, `seo-aeo.md` |
| References | `schema-types.md` (2), `google-seo-reference.md` |

`HowTo` was already correctly listed as deprecated, and the CWV reference already has the INP/FID switch right — `FAQPage` was the outlier.

## Validation

```
python3 -m pytest tests/ -q                                              # 34 passed
python3 scripts/validate_skill_inventory.py                              # OK
python3 scripts/reference_freshness.py resources/references --max-age-days 90
python3 -m compileall scripts                                            # OK
```

`<!-- Updated: -->` markers bumped on both changed reference files, per CONTRIBUTING. `reference_freshness.py` reports them as fresh; the one remaining WARN (`readme-audit-rubric.md`, 155 days) is pre-existing and untouched by this PR.

Independent of #35, which fixes the author/date extractors — no overlapping lines.